### PR TITLE
Apply Several Fixes To Prevent Endless Loops

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.internetitem</groupId>
     <artifactId>logback-elasticsearch-appender</artifactId>
-    <version>1.6-eocs.3</version>
+    <version>1.6-eocs.3.0.1</version>
     <packaging>jar</packaging>
 
     <name>Logback Elasticsearch Appender</name>

--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
@@ -182,18 +182,20 @@ public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
 	}
 
 	private void serializeEvent(JsonGenerator gen, T event, List<AbstractPropertyAndEncoder<T>> propertyList) throws IOException {
-		gen.writeStartObject();
+		try {
+			gen.writeStartObject();
 
-		serializeCommonFields(gen, event);
+			serializeCommonFields(gen, event);
 
-		for (AbstractPropertyAndEncoder<T> pae : propertyList) {
-			String value = pae.encode(event);
-			if (pae.allowEmpty() || (value != null && !value.isEmpty())) {
-				gen.writeObjectField(pae.getName(), value);
+			for (AbstractPropertyAndEncoder<T> pae : propertyList) {
+				String value = pae.encode(event);
+				if (pae.allowEmpty() || (value != null && !value.isEmpty())) {
+					gen.writeObjectField(pae.getName(), value);
+				}
 			}
+		} finally {
+			gen.writeEndObject();
 		}
-
-		gen.writeEndObject();
 	}
 
 	protected abstract void serializeCommonFields(JsonGenerator gen, T event) throws IOException;

--- a/src/main/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchPublisher.java
@@ -1,8 +1,5 @@
 package com.internetitem.logback.elasticsearch;
 
-import java.io.IOException;
-import java.util.Map;
-
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Context;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -13,6 +10,9 @@ import com.internetitem.logback.elasticsearch.config.Settings;
 import com.internetitem.logback.elasticsearch.util.AbstractPropertyAndEncoder;
 import com.internetitem.logback.elasticsearch.util.ClassicPropertyAndEncoder;
 import com.internetitem.logback.elasticsearch.util.ErrorReporter;
+
+import java.io.IOException;
+import java.util.Map;
 
 public class ClassicElasticsearchPublisher extends AbstractElasticsearchPublisher<ILoggingEvent> {
 
@@ -34,13 +34,15 @@ public class ClassicElasticsearchPublisher extends AbstractElasticsearchPublishe
             gen.writeRawValue(event.getFormattedMessage());
         } else {
             String formattedMessage = event.getFormattedMessage();
-            if (settings.getMaxMessageSize() > 0 && formattedMessage.length() > settings.getMaxMessageSize()) {
+            if (settings.getMaxMessageSize() > 0
+                    && formattedMessage != null
+                    && formattedMessage.length() > settings.getMaxMessageSize()) {
                 formattedMessage = formattedMessage.substring(0, settings.getMaxMessageSize()) + "..";
             }
             gen.writeObjectField("message", formattedMessage);
         }
 
-        if(settings.isIncludeMdc()) {
+        if (settings.isIncludeMdc()) {
             for (Map.Entry<String, String> entry : event.getMDCPropertyMap().entrySet()) {
                 gen.writeObjectField(entry.getKey(), entry.getValue());
             }

--- a/src/main/java/com/internetitem/logback/elasticsearch/ElasticsearchOutputAggregator.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/ElasticsearchOutputAggregator.java
@@ -63,6 +63,12 @@ public class ElasticsearchOutputAggregator extends Writer {
 		return success;
 	}
 
+	public void reset() {
+		for (SafeWriter writer : writers) {
+			writer.reset();
+		}
+	}
+
 	@Override
 	public void flush() throws IOException {
 		// No-op

--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
@@ -110,8 +110,7 @@ public class ElasticsearchWriter implements SafeWriter {
 	}
 
 	private static String slurpErrors(HttpURLConnection urlConnection) {
-		try {
-			InputStream stream = urlConnection.getErrorStream();
+		try (InputStream stream = urlConnection.getErrorStream()) {
 			if (stream == null) {
 				return "<no data>";
 			}

--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
@@ -109,6 +109,11 @@ public class ElasticsearchWriter implements SafeWriter {
 		return !sendBuffer.isEmpty();
 	}
 
+	@Override
+	public void reset() {
+		resetBuffer();
+	}
+
 	private static String slurpErrors(HttpURLConnection urlConnection) {
 		try (InputStream stream = urlConnection.getErrorStream()) {
 			if (stream == null) {

--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/LoggerWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/LoggerWriter.java
@@ -27,4 +27,9 @@ public class LoggerWriter implements SafeWriter {
 	public boolean hasPendingData() {
 		return false;
 	}
+
+	@Override
+	public void reset() {
+		// No-op
+	}
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/SafeWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/SafeWriter.java
@@ -9,4 +9,6 @@ public interface SafeWriter {
 	void sendData() throws IOException;
 
 	boolean hasPendingData();
+
+	void reset();
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/StdErrWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/StdErrWriter.java
@@ -13,4 +13,9 @@ public class StdErrWriter implements SafeWriter {
 	public boolean hasPendingData() {
 		return false;
 	}
+
+	@Override
+	public void reset() {
+		// No-op
+	}
 }


### PR DESCRIPTION
**Changes**
- Ensure streams get closed in case of an error
- Make serialization of logging events more resilient to errors
- Improve overall error handling (most of 4xx errors are now causing the buffer to be reset immediately)
- Improve retry-handling (retry counter won't be reset in case new events have been received)